### PR TITLE
Add `split_paired_collection` tool as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "split-paired-collection"]
+	path = split-paired-collection
+	url = https://github.com/scottx611x/split-paired-collection


### PR DESCRIPTION
I think this makes sense as a submodule since `split_paired_collection` has its own CI/CD pipeline